### PR TITLE
feat: support using tsconfig files for compilerOptions

### DIFF
--- a/.changeset/slimy-hairs-poke.md
+++ b/.changeset/slimy-hairs-poke.md
@@ -1,0 +1,5 @@
+---
+"@effect/docgen": patch
+---
+
+Add support for resolving compilerOptions from tsconfig files

--- a/docgen.json
+++ b/docgen.json
@@ -1,28 +1,6 @@
 {
   "exclude": ["src/internal_effect_untraced/**/*.ts"],
   "theme": "mikearnaldi/just-the-docs",
-  "parseCompilerOptions": {
-    "strict": true,
-    "noEmit": true,
-    "target": "ES2021",
-    "lib": ["ES2021"],
-    "paths": {
-      "@effect/docgen": ["./src/index.ts"],
-      "@effect/docgen/test/*": ["./test/*"],
-      "@effect/docgen/examples/*": ["./examples/*"],
-      "@effect/docgen/*": ["./src/*"]
-    }
-  },
-  "examplesCompilerOptions": {
-    "strict": true,
-    "noEmit": true,
-    "target": "ES2021",
-    "lib": ["ES2021"],
-    "paths": {
-      "@effect/docgen": ["../../src/index.ts"],
-      "@effect/docgen/test/*": ["../../test/*"],
-      "@effect/docgen/examples/*": ["../../examples/*"],
-      "@effect/docgen/*": ["../../src/*"]
-    }
-  }
+  "parseCompilerOptions": "./tsconfig.json",
+  "examplesCompilerOptions": "./tsconfig.examples.json"
 }

--- a/docs/modules/Config.ts.md
+++ b/docs/modules/Config.ts.md
@@ -90,7 +90,11 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const ConfigLive: Layer.Layer<unknown, unknown, Config>
+export declare const ConfigLive: Layer.Layer<
+  Process.Process | FileSystem.FileSystem,
+  FileSystem.ReadFileError | FileSystem.ParseJsonError | ConfigError,
+  Config
+>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -64,7 +64,7 @@ Added in v1.0.0
 ```ts
 export declare const parseFiles: (
   files: ReadonlyArray<FileSystem.File>
-) => Effect.Effect<Config.Config, string[][], Domain.Module[]>
+) => Effect.Effect<Process.Process | Config.Config, string[][], Domain.Module[]>
 ```
 
 Added in v1.0.0

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "prettier": "^2.8.8",
     "rimraf": "^5.0.1",
     "ts-morph": "^19.0.0",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "tsconfck": "^2.1.2"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   ts-node:
     specifier: ^10.9.1
     version: 10.9.1(@types/node@20.4.8)(typescript@5.1.6)
+  tsconfck:
+    specifier: ^2.1.2
+    version: 2.1.2(typescript@5.1.6)
 
 devDependencies:
   '@changesets/changelog-github':
@@ -4869,6 +4872,19 @@ packages:
       typescript: 5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  /tsconfck@2.1.2(typescript@5.1.6):
+    resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
+    peerDependencies:
+      typescript: ^4.3.5 || ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.1.6
+    dev: false
 
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@effect/docgen": [
+        "../../src/index.ts"
+      ],
+      "@effect/docgen/test/*": [
+        "../../test/*"
+      ],
+      "@effect/docgen/examples/*": [
+        "../../examples/*"
+      ],
+      "@effect/docgen/*": [
+        "../../src/*"
+      ]
+    }
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,13 @@
     "forceConsistentCasingInFileNames": true,
     "stripInternal": true,
     "skipLibCheck": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "paths": {
+      "@effect/docgen": ["./src/index.ts"],
+      "@effect/docgen/test/*": ["./test/*"],
+      "@effect/docgen/examples/*": ["./examples/*"],
+      "@effect/docgen/*": ["./src/*"]
+    }
   },
   "include": ["./src", "./test"]
 }


### PR DESCRIPTION
## Summary

- Adds support for resolving a tsconfig file for compilerOptions with support for `extends` through the use of `tsconfck`. 
- Fixes converting the raw compilerOptions from a json file, including docgen.json, and converts them into the format that ts-morph/typescript expects of `ts.CompilerOptions`.

## Details 

I'm working on creating a monorepo based on `@effect/platform`, but with 19 different packages, and I'm finding that the repetition is quite a lot to write and maintain. Being able to utilize `extends` would be really helpful to minimizing duplication.

Additionally, things like `"moduleResolution": "node"` leads to runtime errors with the current compilerOptions provided to `ts-morph` since they are not converted to the corresponding enums defined by TS. Becomes a lot more noticeable when you're reading from tsconfigs which likely define more options.