### PR TITLE
fix: parsing regression between versions

### DIFF
--- a/.changeset/weak-pears-worry.md
+++ b/.changeset/weak-pears-worry.md
@@ -1,0 +1,5 @@
+---
+"@effect/docgen": patch
+---
+
+Fix parsing regression caused by compilerOptions parsing

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1104,12 +1104,14 @@ const createProject = (files: ReadonlyArray<FileSystem.File>) =>
         {
           compilerOptions: {
             strict: true,
+            moduleResolution: "node",
             ...config.parseCompilerOptions
           }
         },
         ast.ts.sys,
         cwd
       )
+
       const options: ast.ProjectOptions = {
         compilerOptions: parsed.options
       }


### PR DESCRIPTION
I can locally confirm that it fixes the parsing regression within `@effect/schema` and `@effect/io` by making this change within the `node_modules` of `@effect/schema` pre and post, where pre there were multiple instances of `any` or widening of types, and post there were no visible changes to the git project.

I pretty much just logged out the different compilerOptions between 0.1.4 and 0.1.5 and noticed that after parsing the JSON file content with `ts.parseJsonConfigFileContent`, the only real difference is `target: 8 /* ts.ScriptTarget.ES2021 */` being appended to it automatically. I attempt utilizing ScriptTarget.ES3/5/2015/2018/Latest but all of them resulted in parsing differences. It's my assumption that this is some kind of bug in ts-morph, or maybe even TS, parsing with a target provided vs it being `undefined`, so I just added a `delete` on that specific key to get past the current issue.

## Update 

It turned out to be the change between module resolution when providing a target. So I updated the PR to just provide `"moduleResolution": "node"` as the default resolution method, which I think will provide the most expected behaviors by default.