### PR TITLE
feat: Support for parsing "export * as namespace"

### DIFF
--- a/.changeset/unlucky-tips-cheer.md
+++ b/.changeset/unlucky-tips-cheer.md
@@ -1,0 +1,5 @@
+---
+"@effect/docgen": patch
+---
+
+Support for parsing "export \* as namespace"

--- a/test/Parser.ts
+++ b/test/Parser.ts
@@ -1255,6 +1255,84 @@ describe.concurrent("Parser", () => {
           ])
         )
       })
+
+      it("parses export *", () => {
+        project.createSourceFile("example.ts", `export const a = 1`, { overwrite: true })
+
+        const sourceFile = project.createSourceFile(
+          "export-all.ts",
+          `
+           /**
+            * @since 1.0.0
+            */
+           export * from './example'
+          `
+        )
+
+        const actual = Parser.parseExports.pipe(
+          Effect.provideService(Parser.Source, {
+            path: ["test"],
+            sourceFile
+          }),
+          Effect.provideService(Config.Config, defaultConfig),
+          Effect.runSyncExit
+        )
+
+        expect(actual).toEqual(
+          Exit.succeed([
+            {
+              _tag: "Export",
+              name: "From './example'",
+              description: Option.some("Re-exports all named exports from the './example' module."),
+              since: Option.some("1.0.0"),
+              deprecated: false,
+              signature: "export * from './example'",
+              category: Option.some("exports"),
+              examples: []
+            }
+          ])
+        )
+      })
+
+      it("parse export * as", () => {
+        project.createSourceFile("example.ts", `export const a = 1`, { overwrite: true })
+
+        const sourceFile = project.createSourceFile(
+          "export-all-namespace.ts",
+          `
+            /**
+             * @since 1.0.0
+             */
+            export * as example from './example'
+          `
+        )
+
+        const actual = Parser.parseExports.pipe(
+          Effect.provideService(Parser.Source, {
+            path: ["test"],
+            sourceFile
+          }),
+          Effect.provideService(Config.Config, defaultConfig),
+          Effect.runSyncExit
+        )
+
+        expect(actual).toEqual(
+          Exit.succeed([
+            {
+              _tag: "Export",
+              name: "From './example'",
+              description: Option.some(
+                `Re-exports all named exports from the './example' module as "example".`
+              ),
+              since: Option.some("1.0.0"),
+              deprecated: false,
+              signature: "export * as example from './example'",
+              category: Option.some("exports"),
+              examples: []
+            }
+          ])
+        )
+      })
     })
 
     describe.concurrent("parseModule", () => {


### PR DESCRIPTION
This provides a fairly minor extension to the exports parsing to include `export * as namespace` syntax, currently its signature drops the `as namespace` portion.

I also added a test for this new functionality, as well as covered the previously added `export *` functionality that I don't think was tested previously.