### PR TITLE
Fix example type checking and execution on Windows

### DIFF
--- a/.changeset/brown-seahorses-dance.md
+++ b/.changeset/brown-seahorses-dance.md
@@ -1,0 +1,5 @@
+---
+"@effect/docgen": patch
+---
+
+Fixes the type checking and execution of examples on Windows

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -273,8 +273,10 @@ const runTscOnExamples = Effect.gen(function*(_) {
   const platform = yield* _(process.platform)
 
   const tsconfig = path.normalize(path.join(cwd, config.outDir, "examples", "tsconfig.json"))
-  const exe = platform === "win32" ? "tsc.cmd" : "tsc"
-  const command = Command.make(exe, "--noEmit", "--project", tsconfig)
+  const options = ["--noEmit", "--project", tsconfig]
+  const command = platform === "win32"
+    ? Command.runInShell(Command.make("tsc.cmd", ...options), true)
+    : Command.make("tsc", ...options)
 
   yield* _(Effect.logDebug("Running tsc on examples..."))
 
@@ -316,8 +318,10 @@ const runTsxOnExamples = Effect.gen(function*(_) {
   const examples = path.normalize(path.join(cwd, config.outDir, "examples"))
   const tsconfig = path.join(examples, "tsconfig.json")
   const index = path.join(examples, "index.ts")
-  const exe = platform === "win32" ? "tsx.cmd" : "tsx"
-  const command = Command.make(exe, "--tsconfig", tsconfig, index)
+  const options = ["--tsconfig", tsconfig, index]
+  const command = platform === "win32"
+    ? Command.runInShell(Command.make("tsx.cmd", ...options), true)
+    : Command.make("tsx", ...options)
 
   yield* _(Effect.logDebug("Running tsx on examples..."))
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

The type checking and execution of examples on Windows was broken by the [Node.js security patch for CVE-2024-27980](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2). That update requires that the `{ shell: true }` option be used when running a `cmd` or `bat` file via `child_process.spawn` on Windows, which this pull request implements.
