### PR TITLE
fix: typecheck examples deeply nested within namespaces (#93)

### DIFF
--- a/.changeset/poor-plants-look.md
+++ b/.changeset/poor-plants-look.md
@@ -1,0 +1,5 @@
+---
+"@effect/docgen": patch
+---
+
+Typecheck examples deeply nested within namespaces

--- a/schema.json
+++ b/schema.json
@@ -7,63 +7,51 @@
       "required": [],
       "properties": {
         "$schema": {
-          "type": "string",
-          "description": "a string",
-          "title": "string"
+          "type": "string"
         },
         "projectHomepage": {
           "type": "string",
-          "description": "Will link to the project homepage from the Auxiliary Links of the generated documentation.",
-          "title": "string"
+          "description": "Will link to the project homepage from the Auxiliary Links of the generated documentation."
         },
         "srcDir": {
           "type": "string",
           "description": "The directory in which docgen will search for TypeScript files to parse.",
-          "title": "string",
           "default": "src"
         },
         "outDir": {
           "type": "string",
           "description": "The directory to which docgen will generate its output markdown documents.",
-          "title": "string",
           "default": "docs"
         },
         "theme": {
           "type": "string",
           "description": "The theme that docgen will specify should be used for GitHub Docs in the generated _config.yml file.",
-          "title": "string",
           "default": "mikearnaldi/just-the-docs"
         },
         "enableSearch": {
           "type": "boolean",
           "description": "Whether or not search should be enabled for GitHub Docs in the generated _config.yml file.",
-          "title": "boolean",
           "default": true
         },
         "enforceDescriptions": {
           "type": "boolean",
           "description": "Whether or not descriptions for each module export should be required.",
-          "title": "boolean",
           "default": false
         },
         "enforceExamples": {
           "type": "boolean",
           "description": "Whether or not @example tags for each module export should be required. (Note: examples will not be enforced in module documentation)",
-          "title": "boolean",
           "default": false
         },
         "enforceVersion": {
           "type": "boolean",
           "description": "Whether or not @since tags for each module export should be required.",
-          "title": "boolean",
           "default": true
         },
         "exclude": {
           "type": "array",
           "items": {
-            "type": "string",
-            "description": "a string",
-            "title": "string"
+            "type": "string"
           },
           "description": "An array of glob strings specifying files that should be excluded from the documentation.",
           "default": []
@@ -71,17 +59,17 @@
         "parseCompilerOptions": {
           "anyOf": [
             {
-              "type": "string",
-              "description": "a string",
-              "title": "string"
+              "type": "string"
             },
             {
               "type": "object",
               "required": [],
               "properties": {},
-              "additionalProperties": {
-                "$id": "/schemas/unknown",
-                "title": "unknown"
+              "patternProperties": {
+                "": {
+                  "$id": "/schemas/unknown",
+                  "title": "unknown"
+                }
               }
             }
           ],
@@ -91,17 +79,17 @@
         "examplesCompilerOptions": {
           "anyOf": [
             {
-              "type": "string",
-              "description": "a string",
-              "title": "string"
+              "type": "string"
             },
             {
               "type": "object",
               "required": [],
               "properties": {},
-              "additionalProperties": {
-                "$id": "/schemas/unknown",
-                "title": "unknown"
+              "patternProperties": {
+                "": {
+                  "$id": "/schemas/unknown",
+                  "title": "unknown"
+                }
               }
             }
           ],


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR ensures that we extract the examples from within deeply nested namespaces and not just from the root of the document. I've had to modify the `exampleId` for `interfaces`, `typeAliases`, and `namespaces` so that the intermediary example files all have a unique name. That way, the examples of types, interfaces, and namespaces of the same name but placed at different levels of nesting do not overwrite each other.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #93
